### PR TITLE
Datenschutz und Impressum

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -7,7 +7,8 @@
       <div class="footer-col">
         <p>
           <b>Wann?</b> Jeden Mittwoch in der 7. Stunde<br />
-          <b>Wo?</b> Im Raum 313 oder im SMV-Raum 217
+          <b>Wo?</b> Im Raum 313 oder im SMV-Raum 217<br />
+          Hinweise zum <a href="/datenschutz" title="Datenschutzhinweis"><b>Datenschutz</b></a> und <a href="https://www.ellentalgymnasien.de/impressum" title="Impressum"><b>Impressum</b></a>
         </p>
       </div>
       <div class="footer-col">

--- a/datenschutz.md
+++ b/datenschutz.md
@@ -1,0 +1,55 @@
+---
+layout: default
+---
+# Datenschutzerklärung
+
+## Verantwortlicher und Datenschutzbeauftrager
+Verantwortlicher gem. Art. 4 Abs. 7 EU-Datenschutz-Grundverordnung (EU-DSGVO) ist Land Baden-Württemberg, vertreten durch das Ministerium für Kultus, Jugend und Sport Baden-Württemberg vertreten durch Gymasium I im Ellental und Gymnasium II im Ellental vertreten durch die Schulleiter/innen (siehe im [Impressum](https://www.ellentalgymnasien.de/impressum))
+
+```
+Schwarzwaldstraße 29
+74321 Bietigheim-Bissingen
+Telefon: 07142 74503
+Telefax 07142 74536
+sekretariat@ellentalgymnasien.de
+```
+
+Unseren behördlichen Datenschutzbeauftragten erreichen Sie unter datenschutz@ellentalgymnasien.de. Bei Fragen können sie sich auch an unseren intern mit dem Datenschutz betrauten Kollegen Herr Max wenden.
+
+## Information über die Erhebung personenbezogener Daten, Speicherdauer
+Im Folgenden informieren wir über die Erhebung personenbezogener Daten bei Nutzung unserer Website. Personenbezogene Daten sind alle Daten, die auf Sie persönlich beziehbar sind, z. B. Name, Adresse, E-Mail-Adressen, Nutzerverhalten.
+
+Bei Ihrer Kontaktaufnahme mit uns per E-Mail werden die von Ihnen mitgeteilten Daten (Ihre E-Mail-Adresse, ggf. Ihr Name und Ihre Telefonnummer) von uns gespeichert, um Ihre Fragen zu beantworten. Die in diesem Zusammenhang anfallenden Daten löschen wir, nachdem die Speicherung nicht mehr erforderlich ist, oder schränken die Verarbeitung ein, falls gesetzliche Aufbewahrungspflichten bestehen
+
+Falls wir für einzelne Funktionen unseres Angebots auf beauftragte Dienstleister zurückgreifen oder Ihre Daten für werbliche Zwecke nutzen möchten, werden wir Sie untenstehend im Detail über die jeweiligen Vorgänge informieren. Dabei nennen wir auch die festgelegten Kriterien der Speicherdauer.
+
+## Ihre Rechte
+Sie haben gegenüber uns folgende Rechte hinsichtlich der Sie betreffenden personenbezogenen Daten:
++ Recht auf Auskunft,
++ Recht auf Berichtigung oder Löschung,
++ Recht auf Einschränkung der Verarbeitung
++ Recht auf Widerspruch gegen die Verarbeitung
++ Recht auf Datenübertragbarkeit.
+
+
+Sie haben zudem das Recht, sich bei einer Datenschutz-Aufsichtsbehörde über die Verarbeitung Ihrer personenbezogenen Daten durch uns zu beschweren. Die Datenschutzaufsichtsbehörde ist der Landesbeauftragte für den Datenschutz und die Informationsfreiheit (LfDI), Königstrasse 10a, 70173 Stuttgart.
+
+Werden personenbezogene Daten an ein Drittland oder an eine internationale Organisation übermittelt, so haben Sie das Recht, über die geeigneten Garantien gemäß Art. 46 EU-DSGVO im Zusammenhang mit der Übermittlung unterrichtet zu werden.
+
+## Erhebung und Zweck personenbezogener Daten bei Besuch unserer Webseite
+### Log Daten
+Bei der bloß informatorischen Nutzung der Website, also wenn Sie sich nicht registrieren oder uns anderweitig Informationen übermitteln, erheben wir nur die personenbezogenen Daten, die Ihr Browser an unseren Server übermittelt. Wenn Sie unsere Website betrachten möchten, erheben wir die folgenden Daten, die für uns technisch erforderlich sind, um Ihnen unsere Website anzuzeigen und die Stabilität und Sicherheit zu gewährleisten (Rechtsgrundlage ist Art. 6 Abs. 1 S. 1 lit. f EU-DSGVO):
++ IP-Adresse
++ Datum und Uhrzeit der Anfrage
++ Zeitzonendifferenz zur Greenwich Mean Time (GMT)
++ Inhalt der Anforderung (konkrete Seite)
++ Zugriffsstatus/HTTP-Statuscode
++ jeweils übertragene Datenmenge
++ Website, von der die Anforderung kommt
++ Browser
++ Betriebssystem und dessen Oberfläche
++ Sprache und Version der Browsersoftware.
+
+Github, Inc. erfasst als Betreiber des Webservers folgende Daten:
++ IP-Adresse
+Mehr Details entnehmen Sie bitte der [Datenschutzerklärung](https://docs.github.com/en/github/site-policy/github-privacy-statement) von GitHub selbst.


### PR DESCRIPTION
Dies ist eine mögliche Ausarbeitung zur implementierung von Privacy Policy und Impressum.
Impressum wurde von https://www.ellentalgymnasien.de/impressum übernommen, die Datenschutzerklärung wurde von https://www.ellentalgymnasien.de/datenschutz übernommen und spezifisch für diese Seite abgeändert. Konkret heißt das:
+ Einige Formulierungen wurden leicht geändert
+ Unter `Information über die Erhebung personenbezogener Daten, Speicherdauer` wurde `oder über ein Kontaktformular` entfernt. Es besteht auf dieser Seite nur die Möglichkeit eine Mail an die SMV zu schreiben.
+ Unter `Log Daten` wurde der Serveranbieter antsprechend auf GitHub geändert und der Hinweis zu Cookies wurde komplett entfernt (Diese Seite nutzt keine Cookies)